### PR TITLE
Fix MemoryPool use after return

### DIFF
--- a/CnCNet/Net/PeerToPeer/PeerToPeerUtil.cs
+++ b/CnCNet/Net/PeerToPeer/PeerToPeerUtil.cs
@@ -68,32 +68,39 @@ internal sealed class PeerToPeerUtil(ILogger<PeerToPeerUtil> logger) : IAsyncDis
         while (!cancellationToken.IsCancellationRequested)
         {
             IMemoryOwner<byte> memoryOwner = MemoryPool<byte>.Shared.Rent(64);
-            Memory<byte> buffer = memoryOwner.Memory[..64];
-            var remoteSocketAddress = new SocketAddress(client.AddressFamily);
-            int bytesReceived;
+            bool ownershipTransferred = false;
 
             try
             {
-                bytesReceived = await client.ReceiveFromAsync(buffer, SocketFlags.None, remoteSocketAddress, cancellationToken).ConfigureAwait(false);
-            }
-            catch (SocketException ex)
-            {
-                memoryOwner.Dispose();
-                await logger.LogExceptionDetailsAsync(ex, LogLevel.Warning).ConfigureAwait(false);
-                continue;
-            }
+                Memory<byte> buffer = memoryOwner.Memory[..64];
+                var remoteSocketAddress = new SocketAddress(client.AddressFamily);
+                int bytesReceived;
 
-            if (bytesReceived is 48)
-            {
+                try
+                {
+                    bytesReceived = await client.ReceiveFromAsync(buffer, SocketFlags.None, remoteSocketAddress, cancellationToken).ConfigureAwait(false);
+                }
+                catch (SocketException ex)
+                {
+                    await logger.LogExceptionDetailsAsync(ex, LogLevel.Warning).ConfigureAwait(false);
+                    continue;
+                }
+
+                if (bytesReceived is 48)
+                {
+                    ownershipTransferred = true;
+
 #pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
 #pragma warning disable CA2025 // Do not pass 'IDisposable' instances into unawaited tasks
-                _ = ReceiveAsync(client, memoryOwner, remoteSocketAddress, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
+                    _ = ReceiveAsync(client, memoryOwner, remoteSocketAddress, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
 #pragma warning restore CA2025 // Do not pass 'IDisposable' instances into unawaited tasks
 #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+                }
             }
-            else
+            finally
             {
-                memoryOwner.Dispose();
+                if (!ownershipTransferred)
+                    memoryOwner.Dispose();
             }
         }
     }

--- a/CnCNet/Net/PeerToPeer/PeerToPeerUtil.cs
+++ b/CnCNet/Net/PeerToPeer/PeerToPeerUtil.cs
@@ -1,6 +1,7 @@
 ﻿#pragma warning disable CA1812 // Avoid uninstantiated internal classes
 using System.Buffers;
 using System.Collections.Concurrent;
+using System.Security.Cryptography;
 
 namespace CnCNetServer;
 
@@ -66,7 +67,7 @@ internal sealed class PeerToPeerUtil(ILogger<PeerToPeerUtil> logger) : IAsyncDis
 
         while (!cancellationToken.IsCancellationRequested)
         {
-            using IMemoryOwner<byte> memoryOwner = MemoryPool<byte>.Shared.Rent(64);
+            IMemoryOwner<byte> memoryOwner = MemoryPool<byte>.Shared.Rent(64);
             Memory<byte> buffer = memoryOwner.Memory[..64];
             var remoteSocketAddress = new SocketAddress(client.AddressFamily);
             int bytesReceived;
@@ -77,6 +78,7 @@ internal sealed class PeerToPeerUtil(ILogger<PeerToPeerUtil> logger) : IAsyncDis
             }
             catch (SocketException ex)
             {
+                memoryOwner.Dispose();
                 await logger.LogExceptionDetailsAsync(ex, LogLevel.Warning).ConfigureAwait(false);
                 continue;
             }
@@ -85,17 +87,22 @@ internal sealed class PeerToPeerUtil(ILogger<PeerToPeerUtil> logger) : IAsyncDis
             {
 #pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
 #pragma warning disable CA2025 // Do not pass 'IDisposable' instances into unawaited tasks
-                _ = ReceiveAsync(client, buffer, remoteSocketAddress, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
+                _ = ReceiveAsync(client, memoryOwner, remoteSocketAddress, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
 #pragma warning restore CA2025 // Do not pass 'IDisposable' instances into unawaited tasks
 #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+            }
+            else
+            {
+                memoryOwner.Dispose();
             }
         }
     }
 
-    private async Task ReceiveAsync(Socket client, ReadOnlyMemory<byte> receiveBuffer, SocketAddress remoteSocketAddress, CancellationToken cancellationToken)
+    private async Task ReceiveAsync(Socket client, IMemoryOwner<byte> receiveMemoryOwner, SocketAddress remoteSocketAddress, CancellationToken cancellationToken)
     {
         try
         {
+            ReadOnlyMemory<byte> receiveBuffer = receiveMemoryOwner.Memory[..48];
             var remoteIpEndpoint = (IPEndPoint)new IPEndPoint(0L, 0).Create(remoteSocketAddress);
 
             if (logger.IsEnabled(LogLevel.Debug))
@@ -110,23 +117,22 @@ internal sealed class PeerToPeerUtil(ILogger<PeerToPeerUtil> logger) : IAsyncDis
             using IMemoryOwner<byte> memoryOwner = MemoryPool<byte>.Shared.Rent(40);
             Memory<byte> sendBuffer = memoryOwner.Memory[..40];
 
-#pragma warning disable CA5394 // Do not use insecure randomness
-            new Random().NextBytes(sendBuffer.Span);
-#pragma warning restore CA5394 // Do not use insecure randomness
-            BitConverter.GetBytes(IPAddress.HostToNetworkOrder(StunId)).AsSpan(..2).CopyTo(sendBuffer.Span[6..8]);
             byte[] addressBytes = remoteIpEndpoint.Address.IsIPv4MappedToIPv6 || remoteIpEndpoint.AddressFamily is AddressFamily.InterNetwork
                 ? remoteIpEndpoint.Address.MapToIPv4().GetAddressBytes()
                 : remoteIpEndpoint.Address.GetAddressBytes();
-
-            addressBytes.AsSpan(..addressBytes.Length).CopyTo(sendBuffer.Span[..addressBytes.Length]);
+            addressBytes.CopyTo(sendBuffer.Span[..addressBytes.Length]);
 
             byte[] portBytes = BitConverter.GetBytes(IPAddress.HostToNetworkOrder((short)remoteIpEndpoint.Port));
+            portBytes.CopyTo(sendBuffer.Span[addressBytes.Length..(addressBytes.Length + 2)]);
 
-            portBytes.AsSpan(..portBytes.Length).CopyTo(sendBuffer.Span[addressBytes.Length..(addressBytes.Length + 2)]);
+            byte[] stunIdBytes = BitConverter.GetBytes(IPAddress.HostToNetworkOrder(StunId));
+            stunIdBytes.CopyTo(sendBuffer.Span[(addressBytes.Length + 2)..(addressBytes.Length + 4)]);
 
             // obfuscate
             for (int i = 0; i < addressBytes.Length + portBytes.Length; i++)
                 sendBuffer.Span[i] ^= 0x20;
+
+            RandomNumberGenerator.Fill(sendBuffer.Span[(addressBytes.Length + 4)..]);
 
             _ = await client.SendToAsync(sendBuffer, SocketFlags.None, remoteSocketAddress, cancellationToken).ConfigureAwait(false);
         }
@@ -137,6 +143,10 @@ internal sealed class PeerToPeerUtil(ILogger<PeerToPeerUtil> logger) : IAsyncDis
         catch (Exception ex)
         {
             await logger.LogExceptionDetailsAsync(ex).ConfigureAwait(false);
+        }
+        finally
+        {
+            receiveMemoryOwner.Dispose();
         }
     }
 

--- a/CnCNet/Net/Tunnel/Tunnel.cs
+++ b/CnCNet/Net/Tunnel/Tunnel.cs
@@ -50,7 +50,7 @@ internal abstract class Tunnel(ILogger logger, IOptions<ServiceOptions> serviceO
 
         while (!cancellationToken.IsCancellationRequested)
         {
-            using IMemoryOwner<byte> memoryOwner = MemoryPool<byte>.Shared.Rent(ServiceOptions.Value.MaxPacketSize);
+            IMemoryOwner<byte> memoryOwner = MemoryPool<byte>.Shared.Rent(ServiceOptions.Value.MaxPacketSize);
             Memory<byte> buffer = memoryOwner.Memory[..ServiceOptions.Value.MaxPacketSize];
             var remoteSocketAddress = new SocketAddress(Client.AddressFamily);
             int receivedBytes;
@@ -61,15 +61,19 @@ internal abstract class Tunnel(ILogger logger, IOptions<ServiceOptions> serviceO
             }
             catch (SocketException ex)
             {
+                memoryOwner.Dispose();
                 await Logger.LogExceptionDetailsAsync(ex, LogLevel.Warning).ConfigureAwait(false);
                 continue;
             }
 
 #pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+#pragma warning disable CA2025 // Do not pass 'IDisposable' instances into unawaited tasks
             _ = DoReceiveAsync(
-                buffer[..receivedBytes],
+                memoryOwner,
+                receivedBytes,
                 remoteSocketAddress,
                 cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
+#pragma warning restore CA2025 // Do not pass 'IDisposable' instances into unawaited tasks
 #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
         }
     }
@@ -203,10 +207,11 @@ internal abstract class Tunnel(ILogger logger, IOptions<ServiceOptions> serviceO
         return false;
     }
 
-    private async Task DoReceiveAsync(ReadOnlyMemory<byte> buffer, SocketAddress socketAddress, CancellationToken cancellationToken)
+    private async Task DoReceiveAsync(IMemoryOwner<byte> memoryOwner, int receivedBytes, SocketAddress socketAddress, CancellationToken cancellationToken)
     {
         try
         {
+            ReadOnlyMemory<byte> buffer = memoryOwner.Memory[..receivedBytes];
             if (buffer.Length < MinimumPacketSize || buffer.Length > ServiceOptions.Value.MaxPacketSize)
             {
                 if (Logger.IsEnabled(LogLevel.Debug))
@@ -224,6 +229,10 @@ internal abstract class Tunnel(ILogger logger, IOptions<ServiceOptions> serviceO
         catch (Exception ex)
         {
             await Logger.LogExceptionDetailsAsync(ex).ConfigureAwait(false);
+        }
+        finally
+        {
+            memoryOwner.Dispose();
         }
     }
 

--- a/CnCNet/Net/Tunnel/Tunnel.cs
+++ b/CnCNet/Net/Tunnel/Tunnel.cs
@@ -51,30 +51,41 @@ internal abstract class Tunnel(ILogger logger, IOptions<ServiceOptions> serviceO
         while (!cancellationToken.IsCancellationRequested)
         {
             IMemoryOwner<byte> memoryOwner = MemoryPool<byte>.Shared.Rent(ServiceOptions.Value.MaxPacketSize);
-            Memory<byte> buffer = memoryOwner.Memory[..ServiceOptions.Value.MaxPacketSize];
-            var remoteSocketAddress = new SocketAddress(Client.AddressFamily);
-            int receivedBytes;
+            bool ownershipTransferred = false;
 
             try
             {
-                receivedBytes = await Client.ReceiveFromAsync(buffer, SocketFlags.None, remoteSocketAddress, cancellationToken).ConfigureAwait(false);
-            }
-            catch (SocketException ex)
-            {
-                memoryOwner.Dispose();
-                await Logger.LogExceptionDetailsAsync(ex, LogLevel.Warning).ConfigureAwait(false);
-                continue;
-            }
+                Memory<byte> buffer = memoryOwner.Memory[..ServiceOptions.Value.MaxPacketSize];
+                var remoteSocketAddress = new SocketAddress(Client.AddressFamily);
+                int receivedBytes;
+
+                try
+                {
+                    receivedBytes = await Client.ReceiveFromAsync(buffer, SocketFlags.None, remoteSocketAddress, cancellationToken).ConfigureAwait(false);
+                }
+                catch (SocketException ex)
+                {
+                    await Logger.LogExceptionDetailsAsync(ex, LogLevel.Warning).ConfigureAwait(false);
+                    continue;
+                }
+
+                ownershipTransferred = true;
 
 #pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
 #pragma warning disable CA2025 // Do not pass 'IDisposable' instances into unawaited tasks
-            _ = DoReceiveAsync(
-                memoryOwner,
-                receivedBytes,
-                remoteSocketAddress,
-                cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
+                _ = DoReceiveAsync(
+                    memoryOwner,
+                    receivedBytes,
+                    remoteSocketAddress,
+                    cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
 #pragma warning restore CA2025 // Do not pass 'IDisposable' instances into unawaited tasks
 #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+            }
+            finally
+            {
+                if (!ownershipTransferred)
+                    memoryOwner.Dispose();
+            }
         }
     }
 

--- a/CnCNet/Net/Tunnel/TunnelV2.cs
+++ b/CnCNet/Net/Tunnel/TunnelV2.cs
@@ -1,4 +1,5 @@
 ﻿#pragma warning disable CA1812 // Avoid uninstantiated internal classes
+using System.Security.Cryptography;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -234,13 +235,9 @@ internal sealed class TunnelV2(ILogger<TunnelV2> logger, IOptions<ServiceOptions
                     $"New V{Version} lobby from host {host} with {clients} clients."));
             }
 
-            var rand = new Random();
-
             while (clients > 0)
             {
-#pragma warning disable CA5394 // Do not use insecure randomness
-                int clientId = rand.Next(0, short.MaxValue);
-#pragma warning restore CA5394 // Do not use insecure randomness
+                int clientId = RandomNumberGenerator.GetInt32(0, short.MaxValue);
 
                 if (!Mappings.TryAdd((uint)clientId, new(ServiceOptions.Value.ClientTimeout)))
                     continue;


### PR DESCRIPTION
Processing tasks may read/forward data after the memory has already been returned to the pool, leading to occasional packet errors/corrupted data.

The `StunId` in `PeerToPeerUtil` was overwritten by IPv6 address, which seems to be a mistake.

In addition, creating a new `Random` instance each time is also unfriendly to multithreading, so it has been replaced with the more modern `RandomNumberGenerator`.